### PR TITLE
Update plugins.md

### DIFF
--- a/_sigil/plugins.md
+++ b/_sigil/plugins.md
@@ -6,6 +6,8 @@ permalink: /sigil/plugins/
 {% include remote_versions.html %}
 Sigil supports a number of [plugins](https://www.mobileread.com/forums/forumdisplay.php?f=268) that enhance and extend Sigil. Please see the [Plugin Index](https://www.mobileread.com/forums/showthread.php?t=247431) for a list of plugins.
 
+For information about how to install plugins, see the "Manage plugins" section of the Sigil user guide.
+
 [View Sigil Plugin API Guide Online](https://sigil-ebook.com/plugin-api-guide){:target="_blank" rel="noopener" .btn .btn--success}
 [Download Latest Sigil Plugin API Guide](https://github.com/Sigil-Ebook/plugin-api-guide/releases/download/{{ api_guide_ver }}/Sigil_Plugin_API_Guide_{{ api_guide_ver }}.epub){: .btn .btn--success}
 


### PR DESCRIPTION
Adding info about where to find installation instructions.

(This line would've saved me a lot of time last night--if you do a web search for [sigil plugin install], the user guide doesn't come up, but this page does. So it would be super useful to beginners to explicitly point from this page to where the installation instructions live.)